### PR TITLE
Spawn pads now work with "All" no matter the phase

### DIFF
--- a/src/objects/player.ts
+++ b/src/objects/player.ts
@@ -97,7 +97,7 @@ export default class Player {
         let phase = this.room.state.session.phase;
         let spawnpadPhase = phase === "preGame" ? "Pre-Game" : "Game";
         let spawnPads = this.room.devices.getDevices("characterSpawnPad");
-        spawnPads = spawnPads.filter((s) => s.options.phase === spawnpadPhase);
+        spawnPads = spawnPads.filter((s) => s.options.phase === spawnpadPhase || s.options.phase === "All");
         
         let x = 16000, y = 16000;
         if(spawnPads.length > 0) {


### PR DESCRIPTION
Spawn pads used to only work with game and pre-game, even, so all would never be used. Now it is. Basically just made the all option always be in the spawn pads that it can use.